### PR TITLE
Typo in help text fixed.

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -67,7 +67,7 @@ func main() {
     *height = *height / 2
 
 	if flag.NArg() < 1 {
-		fmt.Println("Usage: gofetch [options] /path/to/file.gif")
+		fmt.Println("Usage: brrtfetch [options] /path/to/file.gif")
 		flag.PrintDefaults()
 		return
 	}


### PR DESCRIPTION
The help text displayed when the command is ran without arguments used the old project name. This commit fixes it.